### PR TITLE
[ZERO-5754]: Ambiguous error message is displayed when user gets acs error via SAML login

### DIFF
--- a/src/esaml_sp.erl
+++ b/src/esaml_sp.erl
@@ -277,20 +277,17 @@ validate_assertion(Xml, DuplicateFun, SP = #esaml_sp{}) ->
             end
         end,
         fun(A) ->
-            if
-                SP#esaml_sp.idp_signs_envelopes ->
-                    case xmerl_dsig:verify(Xml, SP#esaml_sp.trusted_fingerprints) of
-                        ok -> A;
-                        OuterError -> {error, {envelope, OuterError}}
-                    end;
-                true -> A
-            end
-        end,
-        fun(A) ->
             if SP#esaml_sp.idp_signs_assertions ->
                 case xmerl_dsig:verify(A, SP#esaml_sp.trusted_fingerprints) of
                     ok -> A;
-                    InnerError -> {error, {assertion, InnerError}}
+                    InnerError -> 
+                        if SP#esaml_sp.idp_signs_envelopes ->
+                            case xmerl_dsig:verify(Xml, SP#esaml_sp.trusted_fingerprints) of
+                                ok -> A;
+                                OuterError -> {error, {envelope, OuterError}}
+                            end;
+                        true -> {error, {assertion, InnerError}}
+                        end
                 end;
             true -> A
             end


### PR DESCRIPTION
 updated the requirement of checking for a < Signature /> element under < samlp:Response /> as a fallback when the default check under < Assertion /> path fails
 
 
 
< Signature/ > under <samlp:Response>
<img width="1179" alt="Screenshot 2024-07-02 at 10 39 42" src="https://github.com/oviceinc/ex-api/assets/29795863/cfc891f0-11f1-4fd8-aa11-b95fa7e03ea2">

default < Signature/ > under < Assertion />
<img width="1179" alt="Screenshot 2024-07-02 at 10 41 37" src="https://github.com/oviceinc/ex-api/assets/29795863/86967454-0ab8-4a97-aa51-079bcc80f3a8">